### PR TITLE
Allow shortcut.exe path to be specified

### DIFF
--- a/lib/windows-shortcuts.js
+++ b/lib/windows-shortcuts.js
@@ -84,10 +84,6 @@ function generateFileExecArgs(type, path, options) {
 	return args;
 }
 
-function generateFileExecCommand() {
-  return require("path").join(__dirname, "shortcut", "shortcut.exe");
-}
-
 function generateCommand(type, path, options) {
 	// Generates a command for shortcut.exe
 	var command = '"' + __dirname + '/shortcut/shortcut.exe"' +
@@ -128,7 +124,7 @@ exports.query = function(path, callback) {
 		});
 };
 
-exports.create = function(path, optionsOrCallbackOrTarget, callback) {
+exports.create = function(shortcutExePath, path, optionsOrCallbackOrTarget, callback) {
 	var options = isString(optionsOrCallbackOrTarget) ? {target : optionsOrCallbackOrTarget} : optionsOrCallbackOrTarget;
 	callback = typeof optionsOrCallbackOrTarget === 'function' ? optionsOrCallbackOrTarget : callback;
 
@@ -139,7 +135,7 @@ exports.create = function(path, optionsOrCallbackOrTarget, callback) {
 	        	"New Shortcut.lnk"));
 	}
 
-	execFile(generateFileExecCommand(), generateFileExecArgs('C', path, options),
+	execFile(shortcutExePath, generateFileExecArgs('C', path, options),
 	     function(error, stdout, stderr) {
 		 	if (callback)
 				callback(error ? stderr || stdout : null);


### PR DESCRIPTION
@ahmedalsudani @fjvallarino This allows the path to shortcut.exe to be passed in so that we can indicate a path outside the asar.
